### PR TITLE
Fixed `HashGenerator`, `$amount` data type changed to `string`

### DIFF
--- a/src/Util/HashGenerator.php
+++ b/src/Util/HashGenerator.php
@@ -17,7 +17,7 @@ class HashGenerator {
      * @param string $ipnSecret IPN Secret of the merchant
      * @return string
      */
-    public static function generate(string $merchantTransactionId, string $currency, float $amount, string $status, string $ipnSecret): string {
+    public static function generate(string $merchantTransactionId, string $currency, string $amount, string $status, string $ipnSecret): string {
         return strtoupper(hash('sha256', $merchantTransactionId.$currency.$amount.$status.$ipnSecret));
     }
 }


### PR DESCRIPTION
Hi @obanach 

I recently encountered an issue where the incoming Zen IPN data had a value of `2.70`, which led to a hash mismatch. Upon deeper investigation, I discovered that in the `HashGenerator::generate` function, the `$amount` parameter type is set to `float`. I'm unsure how PHP handles internal type juggling, but for some reason, the float value was being interpreted as `2.7`, while the hash in the payload was generated using `2.70`.